### PR TITLE
Make the number of repos returned configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const controlAccess = require('control-access');
 const token = process.env.GITHUB_TOKEN;
 const username = process.env.GITHUB_USERNAME;
 const origin = process.env.ACCESS_ALLOW_ORIGIN;
+const maxRepos = process.env.MAX_REPOS ? process.env.MAX_REPOS : 6;
 const ONE_DAY = 1000 * 60 * 60 * 24;
 
 if (!token) {
@@ -23,7 +24,7 @@ const query = `
 	query {
 		user(login: "${username}") {
 			repositories(
-				last: 6,
+				last: ${maxRepos},
 				isFork: false,
 				affiliations: OWNER,
 				privacy: PUBLIC,

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const controlAccess = require('control-access');
 const token = process.env.GITHUB_TOKEN;
 const username = process.env.GITHUB_USERNAME;
 const origin = process.env.ACCESS_ALLOW_ORIGIN;
-const maxRepos = process.env.MAX_REPOS ? process.env.MAX_REPOS : 6;
+const maxRepos = Number(process.env.MAX_REPOS) || 6;
 const ONE_DAY = 1000 * 60 * 60 * 24;
 
 if (!token) {

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 I currently use this on [my website](https://sindresorhus.com/#projects).
 
-It returns the 6 latest repos, unless specified otherwise (see [here](env)) and the results are cached for a day.
+It returns the 6 latest repos, unless specified otherwise and the results are cached for a day.
 
 [Example response](example-response.json)
 
@@ -13,12 +13,12 @@ It returns the 6 latest repos, unless specified otherwise (see [here](env)) and 
 
 ### With [`now`](https://now.sh)
 
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/sindresorhus/gh-latest-repos&env=GITHUB_TOKEN&env=GITHUB_USERNAME&env=ACCESS_ALLOW_ORIGIN)
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/sindresorhus/gh-latest-repos&env=GITHUB_TOKEN&env=GITHUB_USERNAME&env=ACCESS_ALLOW_ORIGIN&env=MAX_REPOS)
 
 or
 
 ```
-$ now sindresorhus/gh-latest-repos -e NODE_ENV=production -e GITHUB_TOKEN=xxx -e GITHUB_USERNAME=xxx -e ACCESS_ALLOW_ORIGIN=xxx
+$ now sindresorhus/gh-latest-repos -e NODE_ENV=production -e GITHUB_TOKEN=xxx -e GITHUB_USERNAME=xxx -e ACCESS_ALLOW_ORIGIN=xxx -e MAX_REPOS=xxx
 ```
 
 ### Manual
@@ -26,7 +26,6 @@ $ now sindresorhus/gh-latest-repos -e NODE_ENV=production -e GITHUB_TOKEN=xxx -e
 Deploy to your hosting provider, set the below environment variables, and start it with `npm start`.
 
 
-<a name="env"></a>
 ## Environment variables
 
 Define the following environment variables:

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ Define the following environment variables:
 - `GITHUB_TOKEN` - [Personal access token.](https://github.com/settings/tokens/new?description=gh-latest-repos)
 - `GITHUB_USERNAME` - The username you like to get repos from.
 - `ACCESS_ALLOW_ORIGIN` - The URL of your website or `*` if you want to allow any origin (not recommended), for the `Access-Control-Allow-Origin` header.
-- `MAX_REPOS` - The number of repos returned. This is optional.
+- `MAX_REPOS` - The number of repos returned. Optional. Defaults to 6.
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 I currently use this on [my website](https://sindresorhus.com/#projects).
 
-It returns the 6 latest repos and it's cached for a day.
+It returns the 6 latest repos, unless specified otherwise (see [here](env)) and the results are cached for a day.
 
 [Example response](example-response.json)
 
@@ -26,6 +26,7 @@ $ now sindresorhus/gh-latest-repos -e NODE_ENV=production -e GITHUB_TOKEN=xxx -e
 Deploy to your hosting provider, set the below environment variables, and start it with `npm start`.
 
 
+<a name="env"></a>
 ## Environment variables
 
 Define the following environment variables:
@@ -33,6 +34,7 @@ Define the following environment variables:
 - `GITHUB_TOKEN` - [Personal access token.](https://github.com/settings/tokens/new?description=gh-latest-repos)
 - `GITHUB_USERNAME` - The username you like to get repos from.
 - `ACCESS_ALLOW_ORIGIN` - The URL of your website or `*` if you want to allow any origin (not recommended), for the `Access-Control-Allow-Origin` header.
+- `MAX_REPOS` - The number of repos returned. This is optional.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ import fixture from './example-response';
 const ORIGIN = process.env.ACCESS_ALLOW_ORIGIN;
 const TOKEN = process.env.GITHUB_TOKEN;
 const USERNAME = process.env.GITHUB_USERNAME;
+process.env.MAX_REPOS = 6;
 
 let url;
 
@@ -47,6 +48,11 @@ test.after(() => {
 test('fetch latest repos for user', async t => {
 	const {body} = await got(url, {json: true});
 	t.deepEqual(body, fixture);
+});
+
+test('ensure number of repos returned equals `process.env.MAX_REPOS`', async t => {
+	const {body} = await got(url, {json: true});
+	t.deepEqual(body.length, Number(process.env.MAX_REPOS), `Expected ${process.env.MAX_REPOS}, but got ${body.length}`);
 });
 
 test('set origin header', async t => {


### PR DESCRIPTION
Hey 👋

Currently `example-response.json` contains 6 repos. My test case doesn't _really_ add anything meaningful. I'd like to add more repos to the response file. Although I'm fairly certain my additions work as expected, but just to be sure.

So, when you have time, can you review the changes and also give me something to add to the file so I can test it against my changes better?

Thanks ❤️ 

---

Fixes #4 