### PR TITLE
Add Cache-Control

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const controlAccess = require('control-access');
 const token = process.env.GITHUB_TOKEN;
 const username = process.env.GITHUB_USERNAME;
 const origin = process.env.ACCESS_ALLOW_ORIGIN;
-const cache = "max-age=" + (process.env.CACHE_MAX_AGE || 300);
+const cache = 'max-age=' + (process.env.CACHE_MAX_AGE || 300);
 const maxRepos = Number(process.env.MAX_REPOS) || 6;
 const ONE_DAY = 1000 * 60 * 60 * 24;
 
@@ -75,6 +75,6 @@ fetchRepos();
 
 module.exports = (request, response) => {
 	controlAccess()(request, response);
-	response.setHeader("cache-control", cache)
+	response.setHeader('cache-control', cache);
 	response.end(responseText);
 };

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const controlAccess = require('control-access');
 const token = process.env.GITHUB_TOKEN;
 const username = process.env.GITHUB_USERNAME;
 const origin = process.env.ACCESS_ALLOW_ORIGIN;
+const cache = "max-age=" + (process.env.CACHE_MAX_AGE || 300);
 const maxRepos = Number(process.env.MAX_REPOS) || 6;
 const ONE_DAY = 1000 * 60 * 60 * 24;
 
@@ -74,5 +75,6 @@ fetchRepos();
 
 module.exports = (request, response) => {
 	controlAccess()(request, response);
+	response.setHeader("cache-control", cache)
 	response.end(responseText);
 };

--- a/index.js
+++ b/index.js
@@ -77,13 +77,14 @@ setInterval(fetchRepos, ONE_DAY);
 fetchRepos();
 
 module.exports = (request, response) => {
-	if (request.headers.etag === responseETag) {
-		response.statusCode = 304;
-		response.end();
-	}
-
 	controlAccess()(request, response);
 	response.setHeader('cache-control', cache);
 	response.setHeader('etag', responseETag);
+
+	if (request.headers.etag === responseETag) {
+		response.statusCode = 304;
+		response.end();
+		return;
+	}
 	response.end(responseText);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2280,6 +2280,11 @@
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
 		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+		},
 		"event-emitter": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	},
 	"dependencies": {
 		"control-access": "^0.1.0",
+		"etag": "^1.8.1",
 		"graphql-got": "^0.1.1",
 		"micro": "^8.0.4"
 	},

--- a/readme.md
+++ b/readme.md
@@ -13,12 +13,12 @@ It returns the latest repos along with some metadata. The result is cached for a
 
 ### With [`now`](https://now.sh)
 
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/sindresorhus/gh-latest-repos&env=GITHUB_TOKEN&env=GITHUB_USERNAME&env=ACCESS_ALLOW_ORIGIN&env=MAX_REPOS)
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/sindresorhus/gh-latest-repos&env=GITHUB_TOKEN&env=GITHUB_USERNAME&env=ACCESS_ALLOW_ORIGIN&env=MAX_REPOS&env=CACHE_MAX_AGE)
 
 or
 
 ```
-$ now sindresorhus/gh-latest-repos -e NODE_ENV=production -e GITHUB_TOKEN=xxx -e GITHUB_USERNAME=xxx -e ACCESS_ALLOW_ORIGIN=xxx -e MAX_REPOS=xxx
+$ now sindresorhus/gh-latest-repos -e NODE_ENV=production -e GITHUB_TOKEN=xxx -e GITHUB_USERNAME=xxx -e ACCESS_ALLOW_ORIGIN=xxx -e MAX_REPOS=xxx -e CACHE_MAX_AGE=xxx
 ```
 
 ### Manual
@@ -34,6 +34,7 @@ Define the following environment variables:
 - `GITHUB_USERNAME` - The username you like to get repos from.
 - `ACCESS_ALLOW_ORIGIN` - The URL of your website or `*` if you want to allow any origin (not recommended), for the `Access-Control-Allow-Origin` header.
 - `MAX_REPOS` - The number of repos returned. Optional. Defaults to 6.
+- `CACHE_MAX_AGE` - The maximum age for client cache-control in seconds. Optional. Defaults to 300 (5 minutes).
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -10,6 +10,7 @@ import githubFixture from './github-response';
 const ORIGIN = process.env.ACCESS_ALLOW_ORIGIN;
 const TOKEN = process.env.GITHUB_TOKEN;
 const USERNAME = process.env.GITHUB_USERNAME;
+process.env.CACHE_MAX_AGE = 300;
 process.env.MAX_REPOS = 6;
 
 let url;
@@ -63,4 +64,5 @@ test('ensure number of repos returned equals `process.env.MAX_REPOS`', async t =
 test('set origin header', async t => {
 	const {headers} = await got(url, {json: true});
 	t.is(headers['access-control-allow-origin'], '*');
+	t.is(headers['cache-control'], 'max-age=300');
 });

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ import micro from 'micro';
 import nock from 'nock';
 import testListen from 'test-listen';
 import delay from 'delay';
+import etag from 'etag';
 import fixture from './example-response';
 import githubFixture from './github-response';
 
@@ -62,7 +63,8 @@ test('ensure number of repos returned equals `process.env.MAX_REPOS`', async t =
 });
 
 test('set origin header', async t => {
-	const {headers} = await got(url, {json: true});
+	const {body, headers} = await got(url, {json: true});
 	t.is(headers['access-control-allow-origin'], '*');
 	t.is(headers['cache-control'], 'max-age=300');
+	t.is(headers.etag, etag(JSON.stringify(body)));
 });


### PR DESCRIPTION
Add HTTP Header `cache-control` so that browsers can cache requests for short time, thus saving bandwidth in the long term.

Also adds CACHE_MAX_AGE optional environment variable in case someone wish to modify that.