### PR TITLE
Filter out repos without description

### DIFF
--- a/github-response.json
+++ b/github-response.json
@@ -1,89 +1,212 @@
 [
 	{
-		"name": "alfred-lock",
-		"description": "Alfred 3 workflow to lock your Mac",
-		"url": "https://github.com/sindresorhus/alfred-lock",
-		"primaryLanguage": null,
-		"stargazers": {
-			"totalCount": 34
+		"node": {
+			"name": "alfred-lock",
+			"description": "Alfred 3 workflow to lock your Mac",
+			"url": "https://github.com/sindresorhus/alfred-lock",
+			"primaryLanguage": null,
+			"stargazers": {
+				"totalCount": 34
+			},
+			"forks": {
+				"totalCount": 0
+			}
 		},
-		"forks": {
-			"totalCount": 0
-		}
+		"cursor": ""
 	},
 	{
-		"name": "swift-snippets",
-		"description": "Various nifty Swift snippets and playgrounds I have created",
-		"url": "https://github.com/sindresorhus/swift-snippets",
-		"primaryLanguage": {
-			"name": "Swift",
-			"color": "#ffac45"
+		"node": {
+			"name": "swift-snippets",
+			"description": "Various nifty Swift snippets and playgrounds I have created",
+			"url": "https://github.com/sindresorhus/swift-snippets",
+			"primaryLanguage": {
+				"name": "Swift",
+				"color": "#ffac45"
+			},
+			"stargazers": {
+				"totalCount": 34
+			},
+			"forks": {
+				"totalCount": 0
+			}
 		},
-		"stargazers": {
-			"totalCount": 34
-		},
-		"forks": {
-			"totalCount": 0
-		}
+		"cursor": ""
 	},
 	{
-		"name": "p-progress",
-		"description": "Create a promise that reports progress",
-		"url": "https://github.com/sindresorhus/p-progress",
-		"primaryLanguage": {
-			"name": "JavaScript",
-			"color": "#f1e05a"
+		"node":	{
+			"name": "p-progress",
+			"description": "Create a promise that reports progress",
+			"url": "https://github.com/sindresorhus/p-progress",
+			"primaryLanguage": {
+				"name": "JavaScript",
+				"color": "#f1e05a"
+			},
+			"stargazers": {
+				"totalCount": 648
+			},
+			"forks": {
+				"totalCount": 13
+			}
 		},
-		"stargazers": {
-			"totalCount": 648
-		},
-		"forks": {
-			"totalCount": 13
-		}
+		"cursor": ""
 	},
 	{
-		"name": "is",
-		"description": "Type check values: `is.string('🦄') //=> true`",
-		"url": "https://github.com/sindresorhus/is",
-		"primaryLanguage": {
-			"name": "JavaScript",
-			"color": "#f1e05a"
+		"node":	{
+			"name": "is",
+			"description": "Type check values: `is.string('🦄') //=> true`",
+			"url": "https://github.com/sindresorhus/is",
+			"primaryLanguage": {
+				"name": "JavaScript",
+				"color": "#f1e05a"
+			},
+			"stargazers": {
+				"totalCount": 295
+			},
+			"forks": {
+				"totalCount": 14
+			}
 		},
-		"stargazers": {
-			"totalCount": 295
-		},
-		"forks": {
-			"totalCount": 14
-		}
+		"cursor": ""
 	},
 	{
-		"name": "gh-latest-repos",
-		"description": "Microservice to get the latest public GitHub repos from a user",
-		"url": "https://github.com/sindresorhus/gh-latest-repos",
-		"primaryLanguage": {
-			"name": "JavaScript",
-			"color": "#f1e05a"
+		"node":	{
+			"name": "gh-latest-repos",
+			"description": "Microservice to get the latest public GitHub repos from a user",
+			"url": "https://github.com/sindresorhus/gh-latest-repos",
+			"primaryLanguage": {
+				"name": "JavaScript",
+				"color": "#f1e05a"
+			},
+			"stargazers": {
+				"totalCount": 105
+			},
+			"forks": {
+				"totalCount": 8
+			}
 		},
-		"stargazers": {
-			"totalCount": 105
-		},
-		"forks": {
-			"totalCount": 8
-		}
+		"cursor": ""
 	},
 	{
-		"name": "strip-debug-cli",
-		"description": "Strip console, alert, and debugger statements from JavaScript code",
-		"url": "https://github.com/sindresorhus/strip-debug-cli",
-		"primaryLanguage": {
-			"name": "JavaScript",
-			"color": "#f1e05a"
+		"node": {
+			"name": "strip-debug-cli",
+			"description": "",
+			"url": "https://github.com/sindresorhus/strip-debug-cli",
+			"primaryLanguage": {
+				"name": "JavaScript",
+				"color": "#f1e05a"
+			},
+			"stargazers": {
+				"totalCount": 22
+			},
+			"forks": {
+				"totalCount": 2
+			}
 		},
-		"stargazers": {
-			"totalCount": 22
+		"cursor": ""
+	},
+	{
+		"node": {
+			"name": "alfred-lock",
+			"description": "Alfred 3 workflow to lock your Mac",
+			"url": "https://github.com/sindresorhus/alfred-lock",
+			"primaryLanguage": null,
+			"stargazers": {
+				"totalCount": 34
+			},
+			"forks": {
+				"totalCount": 0
+			}
 		},
-		"forks": {
-			"totalCount": 2
-		}
+		"cursor": ""
+	},
+	{
+		"node": {
+			"name": "swift-snippets",
+			"description": "Various nifty Swift snippets and playgrounds I have created",
+			"url": "https://github.com/sindresorhus/swift-snippets",
+			"primaryLanguage": {
+				"name": "Swift",
+				"color": "#ffac45"
+			},
+			"stargazers": {
+				"totalCount": 34
+			},
+			"forks": {
+				"totalCount": 0
+			}
+		},
+		"cursor": ""
+	},
+	{
+		"node":	{
+			"name": "p-progress",
+			"description": "Create a promise that reports progress",
+			"url": "https://github.com/sindresorhus/p-progress",
+			"primaryLanguage": {
+				"name": "JavaScript",
+				"color": "#f1e05a"
+			},
+			"stargazers": {
+				"totalCount": 648
+			},
+			"forks": {
+				"totalCount": 13
+			}
+		},
+		"cursor": ""
+	},
+	{
+		"node":	{
+			"name": "is",
+			"description": "Type check values: `is.string('🦄') //=> true`",
+			"url": "https://github.com/sindresorhus/is",
+			"primaryLanguage": {
+				"name": "JavaScript",
+				"color": "#f1e05a"
+			},
+			"stargazers": {
+				"totalCount": 295
+			},
+			"forks": {
+				"totalCount": 14
+			}
+		},
+		"cursor": ""
+	},
+	{
+		"node":	{
+			"name": "gh-latest-repos",
+			"description": "Microservice to get the latest public GitHub repos from a user",
+			"url": "https://github.com/sindresorhus/gh-latest-repos",
+			"primaryLanguage": {
+				"name": "JavaScript",
+				"color": "#f1e05a"
+			},
+			"stargazers": {
+				"totalCount": 105
+			},
+			"forks": {
+				"totalCount": 8
+			}
+		},
+		"cursor": ""
+	},
+	{
+		"node": {
+			"name": "strip-debug-cli",
+			"description": "Strip console, alert, and debugger statements from JavaScript code",
+			"url": "https://github.com/sindresorhus/strip-debug-cli",
+			"primaryLanguage": {
+				"name": "JavaScript",
+				"color": "#f1e05a"
+			},
+			"stargazers": {
+				"totalCount": 22
+			},
+			"forks": {
+				"totalCount": 2
+			}
+		},
+		"cursor": ""
 	}
 ]

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const origin = process.env.ACCESS_ALLOW_ORIGIN;
 const cache = `max-age=${Number(process.env.CACHE_MAX_AGE) || 300}`;
 const maxRepos = Number(process.env.MAX_REPOS) || 6;
 const ONE_DAY = 1000 * 60 * 60 * 24;
+let cursor = null;
 
 if (!token) {
 	throw new Error('Please set your GitHub token in the `GITHUB_TOKEN` environment variable');
@@ -34,21 +35,25 @@ const query = `
 					field: CREATED_AT,
 					direction: ASC
 				}
+				before: ${cursor}
 			) {
-				nodes {
-					name
-					description
-					url
-					primaryLanguage {
+				edges {
+					node {
 						name
-						color
+						description
+						url
+						primaryLanguage {
+							name
+							color
+						}
+						stargazers {
+							totalCount
+						}
+						forks {
+							totalCount
+						}
 					}
-					stargazers() {
-						totalCount
-					}
-					forks() {
-						totalCount
-					}
+					cursor
 				}
 			}
 		}
@@ -59,16 +64,32 @@ let responseText = '[]';
 let responseETag = '';
 
 async function fetchRepos() {
-	const {body} = await graphqlGot('api.github.com/graphql', {
-		query,
-		token
-	});
+	let repos = [];
 
-	const repos = body.user.repositories.nodes.map(repo => ({
-		...repo,
-		stargazers: repo.stargazers.totalCount,
-		forks: repo.forks.totalCount
-	}));
+	while (repos.length < maxRepos) {
+		/* eslint-disable no-await-in-loop */
+		const {body} = await graphqlGot('api.github.com/graphql', {
+			query,
+			token
+		});
+
+		const currentRepos = body.user.repositories.edges
+			.filter(edge => edge.node.description)
+			.map(({node: repo}) => ({
+				...repo,
+				stargazers: repo.stargazers.totalCount,
+				forks: repo.forks.totalCount
+			}));
+
+		if (repos.length + currentRepos.length < maxRepos) {
+			repos = repos.concat(currentRepos);
+		} else {
+			repos = repos.concat(currentRepos.slice(repos.length - maxRepos));
+			break;
+		}
+		cursor = body.user.repositories.edges[0].cursor;
+	}
+
 	responseText = JSON.stringify(repos);
 	responseETag = etag(responseText);
 }

--- a/test.js
+++ b/test.js
@@ -21,11 +21,21 @@ test.before(async () => {
 	process.env.GITHUB_TOKEN = 'unicorn';
 	process.env.GITHUB_USERNAME = 'sindresorhus';
 
-	const response = {
+	const response1 = {
 		data: {
 			user: {
 				repositories: {
-					nodes: githubFixture
+					edges: githubFixture.slice(0, 6)
+				}
+			}
+		}
+	};
+
+	const response2 = {
+		data: {
+			user: {
+				repositories: {
+					edges: githubFixture.slice(6)
 				}
 			}
 		}
@@ -35,7 +45,9 @@ test.before(async () => {
 		.filteringPath(pth => `${pth}/`)
 		.matchHeader('authorization', `bearer ${process.env.GITHUB_TOKEN}`)
 		.post('/')
-		.reply(200, response);
+		.reply(200, response1)
+		.post('/')
+		.reply(200, response2);
 
 	url = await testListen(micro(require('.')));
 


### PR DESCRIPTION
fix https://github.com/sindresorhus/gh-latest-repos/issues/12

The implementation takes suggestion in the issue that we do a fetch first, filter out repos with description is null, checks the amount and if less than `maxRepos` do a fetch again, until we reach the `maxRepos` amount of repos. 

The next fetch uses cursor based pagination so I changed the query and added a edge with `cursor`, also added `before` in `repositories`. 