### PR TITLE
Correctly match request headers against ETag

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const graphqlGot = require('graphql-got');
 const controlAccess = require('control-access');
 const etag = require('etag');
+const fresh = require('fresh');
 
 const token = process.env.GITHUB_TOKEN;
 const username = process.env.GITHUB_USERNAME;
@@ -79,14 +80,15 @@ fetchRepos();
 
 module.exports = (request, response) => {
 	controlAccess()(request, response);
-	response.setHeader('cache-control', cache);
-	response.setHeader('etag', responseETag);
 
-	if (request.headers.etag === responseETag) {
+	if (fresh(request.headers, {etag: responseETag})) {
 		response.statusCode = 304;
 		response.end();
 		return;
 	}
+
+	response.setHeader('cache-control', cache);
+	response.setHeader('etag', responseETag);
 
 	response.end(responseText);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2744,6 +2744,11 @@
 				"map-cache": "^0.2.2"
 			}
 		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2770,7 +2775,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2791,12 +2797,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2811,17 +2819,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2938,7 +2949,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2950,6 +2962,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2964,6 +2977,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -2971,12 +2985,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -2995,6 +3011,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3075,7 +3092,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3087,6 +3105,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3172,7 +3191,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3208,6 +3228,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3227,6 +3248,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3270,12 +3292,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	"dependencies": {
 		"control-access": "^0.1.1",
 		"etag": "^1.8.1",
+		"fresh": "^0.5.2",
 		"graphql-got": "^0.1.2",
 		"micro": "^9.3.3"
 	},

--- a/test.js
+++ b/test.js
@@ -68,3 +68,10 @@ test('set origin header', async t => {
 	t.is(headers['cache-control'], 'max-age=300');
 	t.is(headers.etag, etag(JSON.stringify(body)));
 });
+
+test('return cached content', async t => {
+	const {headers: {etag}, statusCode} = await got(url, {json: true});
+	const {statusCode: cachedStatusCode} = await got(url, {json: true, headers: {'if-none-match': etag}});
+	t.is(statusCode, 200);
+	t.is(cachedStatusCode, 304);
+});


### PR DESCRIPTION
Since browsers doesn't send `ETag` as a request header, but `If-None-Match` we have to match against that which `fresh` fixes. Also, we don't need to set `ETag` and `Cache-Control` before eventually returning a cached response.