### PR TITLE
Fix `s-maxage` and remove `CACHE_MAX_AGE` environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const {
 	GITHUB_TOKEN,
 	GITHUB_USERNAME,
 	ACCESS_ALLOW_ORIGIN,
-	CACHE_MAX_AGE = 300,
 	MAX_REPOS = 6
 } = process.env;
 
@@ -91,7 +90,7 @@ module.exports = async (request, response) => {
 		const repos = await fetchRepos();
 
 		response.setHeader('content-type', 'application/json');
-		response.setHeader('cache-control', `s-maxage=${ONE_DAY}, max-age=${CACHE_MAX_AGE}`);
+		response.setHeader('cache-control', `s-maxage=${ONE_DAY}, max-age=0`);
 		response.end(JSON.stringify(repos));
 	} catch (error) {
 		console.error(error);

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const graphqlGot = require('graphql-got');
 const controlAccess = require('control-access');
 
-const ONE_DAY = 1000 * 60 * 60 * 24;
+const ONE_DAY = 60 * 60 * 24;
 
 const {
 	GITHUB_TOKEN,

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ It returns the latest repos along with some metadata. The result is cached for a
 
 ```
 $ git clone https://github.com/sindresorhus/gh-latest-repos.git
-$ now gh-latest-repos --env GITHUB_TOKEN=xxx --env GITHUB_USERNAME=xxx --env ACCESS_ALLOW_ORIGIN=xxx --env MAX_REPOS=xxx --env CACHE_MAX_AGE=xxx
+$ now gh-latest-repos --env GITHUB_TOKEN=xxx --env GITHUB_USERNAME=xxx --env ACCESS_ALLOW_ORIGIN=xxx --env MAX_REPOS=xxx
 ```
 
 ### Manual
@@ -31,4 +31,3 @@ Define the following environment variables:
 - `GITHUB_USERNAME` - The username you like to get repos from.
 - `ACCESS_ALLOW_ORIGIN` - The URL of your website or `*` if you want to allow any origin (not recommended), for the `Access-Control-Allow-Origin` header.
 - `MAX_REPOS` - The number of repos returned. Optional. Defaults to 6.
-- `CACHE_MAX_AGE` - The maximum age for client cache-control in seconds. Optional. Defaults to 300 (5 minutes).

--- a/test.js
+++ b/test.js
@@ -74,5 +74,5 @@ test('ensure number of repos returned equals `process.env.MAX_REPOS`', async t =
 test('set origin header', async t => {
 	const {headers} = await got(url, {json: true});
 	t.is(headers['access-control-allow-origin'], '*');
-	t.is(headers['cache-control'], 's-maxage=86400, max-age=300');
+	t.is(headers['cache-control'], 's-maxage=86400, max-age=0');
 });

--- a/test.js
+++ b/test.js
@@ -74,5 +74,5 @@ test('ensure number of repos returned equals `process.env.MAX_REPOS`', async t =
 test('set origin header', async t => {
 	const {headers} = await got(url, {json: true});
 	t.is(headers['access-control-allow-origin'], '*');
-	t.is(headers['cache-control'], 's-maxage=86400000, max-age=300');
+	t.is(headers['cache-control'], 's-maxage=86400, max-age=300');
 });


### PR DESCRIPTION
I noticed that your latest repos hadn't changed since a while back. This might be the explanation.

https://zeit.co/docs/v2/network/caching/#serverless-functions-(lambdas).

By the way, why do you even need the browser cache header (`maxage`)?