### PR TITLE
Remove alias from now config

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,6 +1,5 @@
 {
 	"version": 2,
-	"alias": "gh-latest-repos",
 	"builds": [
 		{
 			"src": "index.js",


### PR DESCRIPTION
it's throwing an error when try to deploy the repo cause the alias is already taken